### PR TITLE
Switch from deprecated update_xml to data

### DIFF
--- a/l10n_uk_sale_report/__openerp__.py
+++ b/l10n_uk_sale_report/__openerp__.py
@@ -38,7 +38,7 @@
    'author': ['OpusVL', 'Odoo Community Association (OCA)'],
    'website': 'http://opusvl.com',
    'depends': ['account_accountant', 'sale', 'report'],
-   'update_xml': [
+   'data': [
        'views/reports.xml',
    ],
    'license': 'AGPL-3',


### PR DESCRIPTION
Fixed test warning.

openerp.modules.loading:97 _get_files_of_kind module l10n_uk_sale_report: key 'update_xml' is deprecated in favor of 'data' for file 'views/reports.xml'.
